### PR TITLE
swap order of chip-select and SPI transaction begin/end

### DIFF
--- a/src/TMC429/TMC429.cpp
+++ b/src/TMC429/TMC429.cpp
@@ -1139,16 +1139,16 @@ void TMC429::disableChipSelect()
 
 void TMC429::beginTransaction()
 {
-  enableChipSelect();
-  delayMicroseconds(1);
   spiBeginTransaction(SPISettings(SPI_CLOCK, SPI_BIT_ORDER, SPI_MODE));
+  delayMicroseconds(1);
+  enableChipSelect();
 }
 
 void TMC429::endTransaction()
 {
-  spiEndTransaction();
-  delayMicroseconds(1);
   disableChipSelect();
+  delayMicroseconds(1);
+  spiEndTransaction();
 }
 
 void TMC429::spiBegin()


### PR DESCRIPTION
closes #10 

Fix SPI race condition on ESP32 by reordering beginTransaction

Currently, the TMC429 library pulls the chip-select line **before** calling `SPI.beginTransaction`, which can cause race conditions when multiple tasks share the SPI bus.  

This PR swaps the order so that `SPI.beginTransaction` is called first, ensuring proper SPI bus locking before activating the chip-select line. Vice-versa for the end of a transaction.
