### PR TITLE
Fix SPISettings BitOrder type for Mbed-based boards

### DIFF
--- a/src/TMC429.h
+++ b/src/TMC429.h
@@ -173,7 +173,7 @@ private:
 
   // SPISettings
   const static uint32_t SPI_CLOCK = 1000000;
-#if defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_ARCH_RENESAS)
+#if defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_ARCH_RP2040) || defined(ARDUINO_ARCH_RENESAS) || defined(ARDUINO_ARCH_MBED)
   const static BitOrder SPI_BIT_ORDER = MSBFIRST;
 #else
   const static uint8_t SPI_BIT_ORDER = MSBFIRST;


### PR DESCRIPTION
## Problem
On Arduino boards using the Mbed OS core (Portenta H7, Giga R1, Nicla series), 
compilation fails with:

`no instance of constructor "arduino::SPISettings::SPISettings" matches the argument list`

## Cause
The Mbed core defines `BitOrder` as an enum type, but `ARDUINO_ARCH_MBED` was not 
included in the preprocessor check. This caused `SPI_BIT_ORDER` to be declared as 
`uint8_t` instead of `BitOrder`.

## Solution
Added `ARDUINO_ARCH_MBED` to the existing preprocessor conditional in TMC429.h.

## Tested on
- Arduino Portenta H7 (M7 core)
- PlatformIO with Arduino-Mbed framework

## Related boards this fixes
- Arduino Portenta H7
- Arduino Giga R1 WiFi  
- Arduino Nicla Sense ME
- Arduino Nicla Vision
- Any future Mbed-based Arduino boards